### PR TITLE
Fixes default rake task

### DIFF
--- a/lib/haml_lint/rake_task.rb
+++ b/lib/haml_lint/rake_task.rb
@@ -32,7 +32,7 @@ module HamlLint
       @exclude_linter = []
       @config = ''
       @exclude = []
-      @pattern = %w[./**/*.haml]
+      @pattern = Dir.glob('./**/*.haml')
     end
 
     def cli_args
@@ -61,6 +61,8 @@ module HamlLint
       logger = HamlLint::Logger.new(STDOUT)
       result = HamlLint::CLI.new(logger).run(cli_args)
       abort('HamlLint failed') unless result == 0
+
+      result
     end
   end
 end

--- a/spec/haml_lint/rake_task_spec.rb
+++ b/spec/haml_lint/rake_task_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+require 'haml_lint/rake_task'
+
+describe HamlLint::RakeTask do
+  before do
+    # Silence console output
+    # STDOUT.stub(:write)
+  end
+
+  describe '#run' do
+    subject do
+      HamlLint::RakeTask.new
+      Rake::Task['haml_lint']
+    end
+
+    it 'returns a successful exit code' do
+      expect(subject.invoke).to be_truthy
+    end
+  end
+end

--- a/spec/haml_lint/rake_task_spec.rb
+++ b/spec/haml_lint/rake_task_spec.rb
@@ -3,17 +3,17 @@ require 'haml_lint/rake_task'
 
 describe HamlLint::RakeTask do
   before do
-    # Silence console output
-    # STDOUT.stub(:write)
+    @task = HamlLint::RakeTask.new
   end
 
   describe '#run' do
     subject do
-      HamlLint::RakeTask.new
       Rake::Task['haml_lint']
     end
 
     it 'returns a successful exit code' do
+      @task.pattern = __FILE__
+
       expect(subject.invoke).to be_truthy
     end
   end


### PR DESCRIPTION
When I try to add the `haml-lint` rake task to my `Rakefile`, I get the following error: `File path './**/*.haml' does not exist`. I'm doing the "standard":

    require 'haml_lint/rake_task'
    HamlLint::RakeTask.new

This commit should fix it. I added a test borrowed from `scss-lint`.

