### PR TITLE
Add explicit color option

### DIFF
--- a/lib/haml_lint/cli.rb
+++ b/lib/haml_lint/cli.rb
@@ -40,6 +40,7 @@ module HamlLint
     attr_reader :log
 
     def act_on_options(options)
+      log.color_enabled = options[:color]
       if options[:help]
         print_help(options)
         Sysexits::EX_OK

--- a/lib/haml_lint/logger.rb
+++ b/lib/haml_lint/logger.rb
@@ -1,6 +1,9 @@
 module HamlLint
   # Encapsulates all communication to an output source.
   class Logger
+    # Allow manual enabling of colorized output
+    attr_writer :color_enabled
+
     # Creates a logger which outputs nothing.
     # @return [HamlLint::Logger]
     def self.silent
@@ -89,8 +92,15 @@ module HamlLint
 
     private
 
+    # Get whether or not output should be in color
+    #
+    # @return [true, false]
+    def color_enabled
+      @out.tty? || @color_enabled || false
+    end
+
     def color(code, output, newline = true)
-      log(@out.tty? ? "\033[#{code}m#{output}\033[0m" : output, newline)
+      log(color_enabled ? "\033[#{code}m#{output}\033[0m" : output, newline)
     end
   end
 end

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -64,8 +64,8 @@ module HamlLint
         @options[:show_linters] = true
       end
 
-      parser.on('--color', 'Force output to be colorized') do
-        @options[:color] = true
+      parser.on('--[no-]color', 'Force output to be colorized') do |color|
+        @options[:color] = color
       end
 
       parser.on_tail('-h', '--help', 'Display help documentation') do

--- a/lib/haml_lint/options.rb
+++ b/lib/haml_lint/options.rb
@@ -64,6 +64,10 @@ module HamlLint
         @options[:show_linters] = true
       end
 
+      parser.on('--color', 'Force output to be colorized') do
+        @options[:color] = true
+      end
+
       parser.on_tail('-h', '--help', 'Display help documentation') do
         @options[:help] = parser.help
       end

--- a/spec/haml_lint/logger_spec.rb
+++ b/spec/haml_lint/logger_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'haml_lint/logger'
+
+describe HamlLint::Logger do
+  let(:io)     { StringIO.new }
+  let(:logger) { described_class.new(io) }
+
+  describe '#color_enabled' do
+    subject { logger.send :color_enabled }
+
+    describe 'output is a tty' do
+      before { io.stub(:tty?).and_return(true) }
+
+      it { should eq true }
+    end
+
+    describe 'output is not a tty' do
+      before { io.stub(:tty?).and_return(false) }
+
+      it { should eq false }
+    end
+
+    describe 'color_enabled set to true' do
+      before { logger.color_enabled = true }
+
+      it { should eq true }
+    end
+
+    describe 'tty is nil and color_enabled is nil' do
+      before do
+        io.stub(:tty?).and_return(nil)
+        logger.color_enabled = nil
+      end
+
+      it { should eq false }
+    end
+  end
+end

--- a/spec/haml_lint/options_spec.rb
+++ b/spec/haml_lint/options_spec.rb
@@ -55,11 +55,21 @@ describe HamlLint::Options do
       end
     end
 
-    context 'with color manually on' do
-      let(:args) { ['--color'] }
+    context 'color' do
+      describe 'manually on' do
+        let(:args) { ['--color'] }
 
-      it 'sets the `color` option to true' do
-        subject.should include color: true
+        it 'sets the `color` option to true' do
+          subject.should include color: true
+        end
+      end
+
+      describe 'manually off' do
+        let(:args) { ['--no-color'] }
+
+        it 'sets the `color option to false' do
+          subject.should include color: false
+        end
       end
     end
 

--- a/spec/haml_lint/options_spec.rb
+++ b/spec/haml_lint/options_spec.rb
@@ -55,6 +55,14 @@ describe HamlLint::Options do
       end
     end
 
+    context 'with color manually on' do
+      let(:args) { ['--color'] }
+
+      it 'sets the `color` option to true' do
+        subject.should include color: true
+      end
+    end
+
     context 'with a list of file glob patterns' do
       let(:args) { %w[app/**/*.haml some-dir/some-template.haml] }
 


### PR DESCRIPTION
I like running haml-lint in Guard, but Guard always returns `@out.tty?` as `false`, so I followed RSpec's lead and added an explicit --color option