### PR TITLE
Fix line number color for light background ttys

### DIFF
--- a/lib/haml_lint/reporter/default_reporter.rb
+++ b/lib/haml_lint/reporter/default_reporter.rb
@@ -17,7 +17,7 @@ module HamlLint
     def print_location(lint)
       log.info lint.filename, false
       log.log ':', false
-      log.bold lint.line, false
+      log.info lint.line, false
     end
 
     def print_type(lint)


### PR DESCRIPTION
Currently the line number is almost invisible with light background
screens. I think using the same color as the file looks fine and it's a
good compromise.

Another option would be chosing another color that looks fine in all terminals, but I went for the easiest.