### PR TITLE
Check for missing alt attributes on img tags

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -8,6 +8,9 @@
 skip_frontmatter: false
 
 linters:
+  AltText:
+    enabled: false
+
   ClassAttributeWithStaticValue:
     enabled: true
 

--- a/lib/haml_lint/linter/alt_text.rb
+++ b/lib/haml_lint/linter/alt_text.rb
@@ -1,0 +1,11 @@
+module HamlLint
+  class Linter::AltText < Linter
+    include LinterRegistry
+
+    def visit_tag(node)
+      if node.tag_name == 'img' && !node.has_hash_attribute?(:alt)
+        add_lint(node, "`img` tags must include alt text.")
+      end
+    end
+  end
+end

--- a/lib/haml_lint/tree/tag_node.rb
+++ b/lib/haml_lint/tree/tag_node.rb
@@ -20,6 +20,14 @@ module HamlLint::Tree
       @value[:parse] && !@value[:value].strip.empty?
     end
 
+    # Returns whether this tag has a specified attribute
+    # `=`).
+    #
+    # @return [true,false]
+    def has_hash_attribute?(attribute)
+      hash_attributes? && existing_attributes.include?(attribute)
+    end
+
     # List of classes statically defined for this tag.
     #
     # @example For `%tag.button.button-info{ class: status }`, this returns:
@@ -197,6 +205,18 @@ module HamlLint::Tree
     # @return [String]
     def text
       (@value[:value] if @value[:parse]) || ''
+    end
+
+    private
+
+    def parsed_attributes
+      HamlLint::RubyParser.new.parse(hash_attributes_source)
+    end
+
+    def existing_attributes
+      parsed_attributes.children.collect do |parsed_attribute|
+        parsed_attribute.children.first.to_a.first
+      end
     end
   end
 end

--- a/spec/haml_lint/linter/alt_text_spec.rb
+++ b/spec/haml_lint/linter/alt_text_spec.rb
@@ -1,0 +1,17 @@
+require 'spec_helper'
+
+describe HamlLint::Linter::AltText do
+  include_context 'linter'
+
+  context 'when there is no alt attribute' do
+    let(:haml) { '%img' }
+
+    it { should report_lint line: 1 }
+  end
+
+  context 'when there is an alt attribute' do
+    let(:haml) { '%img{ alt: "A relevant description" }' }
+
+    it { should_not report_lint }
+  end
+end

--- a/spec/haml_lint/tree/tag_node_spec.rb
+++ b/spec/haml_lint/tree/tag_node_spec.rb
@@ -5,6 +5,34 @@ describe HamlLint::Tree::TagNode do
   let(:tag_node) { parser.tree.find { |node| node.type == :tag && node.tag_name == tag_name } }
   let(:tag_name) { 'my_tag' }
 
+  describe '#has_hash_attribute?' do
+    subject { tag_node.has_hash_attribute?(:one) }
+
+    context 'when the node has the attribute' do
+      let(:haml) { '%my_tag{ one: 1 }' }
+
+      it { should == true }
+    end
+
+    context 'when the node does not have the attribute' do
+      let(:haml) { '%my_tag{ two: 2 }' }
+
+      it { should == false }
+    end
+
+    context 'when the node has multiple hash attributes' do
+      let(:haml) { '%my_tag{ one: 1, two: 2 }' }
+
+      it { should == true }
+    end
+
+    context 'when the node has no hash attributes' do
+      let(:haml) { '%my_tag' }
+
+      it { should == false  }
+    end
+  end
+
   describe '#dynamic_attributes_source' do
     subject { tag_node.dynamic_attributes_source }
 


### PR DESCRIPTION
This introduces a check that aligns with the W3C WCAG 2.0 guideline 1.1.1, which states:

> All non-text content that is presented to the user has a text alternative that serves the equivalent purpose

http://www.w3.org/TR/2008/REC-WCAG20-20081211/#text-equiv-all

[closes #69]